### PR TITLE
Fix Issue Linking Tweets

### DIFF
--- a/lib/lita/adapters/twitter/connector.rb
+++ b/lib/lita/adapters/twitter/connector.rb
@@ -35,7 +35,7 @@ module Lita
                   mention = true
                 end
                 user    = User.new(tweet.user.id, name: tweet.user.screen_name, mention: mention)
-                source  = Source.new(user: user, room: tweet.id)
+                source  = Source.new(user: user, room: tweet.id.to_s)
                 message = Message.new(robot, text, source)
                 message.command! if mention
                 robot.receive(message)


### PR DESCRIPTION
For a reply to be associated with the original tweet, it has to have 
in_reply_to_status_id set. For that to be set, the room has to be set.
For the room to be properly set in Lita, it must be either a Room
object or a string.

This commit casts tweet.id as a string so it will be properly
recognized as a room.
